### PR TITLE
Fixes NuGet/Home#79 - Use Uri Template for Report Abuse

### DIFF
--- a/src/DataClient/Utility.cs
+++ b/src/DataClient/Utility.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NuGet.Data
@@ -36,6 +35,83 @@ namespace NuGet.Data
             }
 
             return uri;
+        }
+
+        /// <summary>
+        /// Applies a package's id and version to a URI template
+        /// </summary>
+        /// <param name="template">The URI Template</param>
+        /// <param name="id">The id of the package with natural casing</param>
+        /// <param name="version">The version of the package with natural casing</param>
+        /// <returns>The URI with the template fields applied</returns>
+        public static Uri ApplyPackageIdVersionToUriTemplate(Uri template, string id, Versioning.NuGetVersion version)
+        {
+            var packageUri = ApplyPackageIdToUriTemplate(template, id);
+
+            if (packageUri != null)
+            {
+                var versionUrl = packageUri.ToString()
+                    .Replace("{version}", version.ToNormalizedString())
+                    .Replace("{version-lower}", version.ToNormalizedString().ToLowerInvariant());
+
+                Uri versionUri = null;
+                if (Uri.TryCreate(versionUrl, UriKind.Absolute, out versionUri))
+                {
+                    return versionUri;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Applies a package's id and version to a list of URI templates
+        /// </summary>
+        /// <param name="templates">The list of URI templates</param>
+        /// <param name="id">The id of the package with natural casing</param>
+        /// <param name="version">The version of the package with natural casing</param>
+        /// <returns>The list of URIs with the template fields applied</returns>
+        public static IEnumerable<Uri> ApplyPackageIdVersionToUriTemplate(IEnumerable<Uri> templates, string id, Versioning.NuGetVersion version)
+        {
+            foreach (var template in templates)
+            {
+                yield return ApplyPackageIdVersionToUriTemplate(template, id, version);
+            }
+        }
+
+        /// <summary>
+        /// Applies a package's id to a URI template
+        /// </summary>
+        /// <param name="template">The URI template</param>
+        /// <param name="id">The package's id with natural casing</param>
+        /// <returns>The URI with the template fields applied</returns>
+        public static Uri ApplyPackageIdToUriTemplate(Uri template, string id)
+        {
+            var packageUrl = template.ToString()
+                .Replace("{id}", id)
+                .Replace("{id-lower}", id.ToLowerInvariant());
+
+            Uri packageUri = null;
+            if (Uri.TryCreate(packageUrl, UriKind.Absolute, out packageUri))
+            {
+                return packageUri;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Applies a package's id to a list of URI templates
+        /// </summary>
+        /// <param name="templates">The list of URI templates</param>
+        /// <param name="id">The package's id with natural casing</param>
+        /// <returns>The list of URIs with the template fields applied</returns>
+        public static IEnumerable<Uri> ApplyPackageIdToUriTemplate(IEnumerable<Uri> templates, string id)
+        {
+            foreach (var template in templates)
+            {
+                yield return ApplyPackageIdToUriTemplate(template, id);
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Client.V3.VisualStudio/V3UIMetadataResource.cs
+++ b/src/NuGet.Client.V3.VisualStudio/V3UIMetadataResource.cs
@@ -15,10 +15,10 @@ namespace NuGet.Client.V3.VisualStudio
     public class V3UIMetadataResource : UIMetadataResource
     {
         private readonly V3RegistrationResource _regResource;
-        private readonly V3ReportAbuseResouce _reportAbuseResource;
+        private readonly V3ReportAbuseResource _reportAbuseResource;
         private readonly DataClient _client;
 
-        public V3UIMetadataResource(DataClient client, V3RegistrationResource regResource, V3ReportAbuseResouce reportAbuseResource)
+        public V3UIMetadataResource(DataClient client, V3RegistrationResource regResource, V3ReportAbuseResource reportAbuseResource)
             : base()
         {
             _regResource = regResource;

--- a/src/NuGet.Client.V3.VisualStudio/V3UIMetadataResourceProvider.cs
+++ b/src/NuGet.Client.V3.VisualStudio/V3UIMetadataResourceProvider.cs
@@ -35,7 +35,7 @@ namespace NuGet.Client.V3.VisualStudio
             if (await source.GetResourceAsync<V3ServiceIndexResource>(token) != null)
             {
                 var regResource = await source.GetResourceAsync<V3RegistrationResource>();
-                var reportAbuseResource = await source.GetResourceAsync<V3ReportAbuseResouce>();
+                var reportAbuseResource = await source.GetResourceAsync<V3ReportAbuseResource>();
 
                 // construct a new resource
                 curResource = new V3UIMetadataResource(_client, regResource, reportAbuseResource);

--- a/src/NuGet.Client.v3/Client.V3.csproj
+++ b/src/NuGet.Client.v3/Client.V3.csproj
@@ -94,7 +94,7 @@
     <Compile Include="V3RawSearchResourceProvider.cs" />
     <Compile Include="V3RegistrationResource.cs" />
     <Compile Include="V3RegistrationResourceProvider.cs" />
-    <Compile Include="V3ReportAbuseResouce.cs" />
+    <Compile Include="V3ReportAbuseResource.cs" />
     <Compile Include="V3ServiceIndexResource.cs" />
     <Compile Include="V3ServiceIndexResourceProvider.cs" />
     <Compile Include="V3SimpleSearchResource.cs" />

--- a/src/NuGet.Client.v3/Constants.cs
+++ b/src/NuGet.Client.v3/Constants.cs
@@ -26,7 +26,7 @@ namespace NuGet.Client
         public const string SearchGalleryQueryService = "SearchGalleryQueryService" + TypeVersion;
         public const string MetricsService = "MetricsService" + TypeVersion;
         public const string RegistrationsBaseUrl = "RegistrationsBaseUrl" + TypeVersion;
-        public const string ReportAbuse = "ReportAbuse" + TypeVersion;
+        public const string ReportAbuse = "ReportAbuseUriTemplate" + TypeVersion;
     }
 
     public static class Properties

--- a/src/NuGet.Client.v3/ReportAbuseResourceProvider.cs
+++ b/src/NuGet.Client.v3/ReportAbuseResourceProvider.cs
@@ -16,10 +16,10 @@ namespace NuGet.Client
             var serviceIndex = await source.GetResourceAsync<V3ServiceIndexResource>(token);
             if (serviceIndex != null)
             {
-                Uri templateUrl = serviceIndex[ServiceTypes.ReportAbuse].FirstOrDefault();
-                if (templateUrl != null)
+                IEnumerable<Uri> templateUrls = serviceIndex[ServiceTypes.ReportAbuse];
+                if (templateUrls != null && templateUrls.Any())
                 {
-                    resource = new V3ReportAbuseResource(templateUrl);
+                    resource = new V3ReportAbuseResource(templateUrls);
                 }
             }
 

--- a/src/NuGet.Client.v3/ReportAbuseResourceProvider.cs
+++ b/src/NuGet.Client.v3/ReportAbuseResourceProvider.cs
@@ -7,19 +7,19 @@ using System.Threading.Tasks;
 
 namespace NuGet.Client
 {
-    [NuGetResourceProviderMetadata(typeof(V3ReportAbuseResouce), "V3ReportAbuseResouce", NuGetResourceProviderPositions.Last)]
+    [NuGetResourceProviderMetadata(typeof(V3ReportAbuseResource), "V3ReportAbuseResource", NuGetResourceProviderPositions.Last)]
     public class ReportAbuseResourceProvider : INuGetResourceProvider
     {
         public async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
-            V3ReportAbuseResouce resource = null;
+            V3ReportAbuseResource resource = null;
             var serviceIndex = await source.GetResourceAsync<V3ServiceIndexResource>(token);
             if (serviceIndex != null)
             {
                 Uri templateUrl = serviceIndex[ServiceTypes.ReportAbuse].FirstOrDefault();
                 if (templateUrl != null)
                 {
-                    resource = new V3ReportAbuseResouce(templateUrl);
+                    resource = new V3ReportAbuseResource(templateUrl);
                 }
             }
 

--- a/src/NuGet.Client.v3/V3ReportAbuseResource.cs
+++ b/src/NuGet.Client.v3/V3ReportAbuseResource.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace NuGet.Client
 {
-    public class V3ReportAbuseResouce : INuGetResource
+    public class V3ReportAbuseResource : INuGetResource
     {
         string _reportAbuseTemplate;
 
-        public V3ReportAbuseResouce(Uri reportAbuseTemplate)
+        public V3ReportAbuseResource(Uri reportAbuseTemplate)
         {
             _reportAbuseTemplate = reportAbuseTemplate.OriginalString;
         }

--- a/test/Client.V3Test/Client.V3Test.csproj
+++ b/test/Client.V3Test/Client.V3Test.csproj
@@ -74,6 +74,7 @@
     <Compile Include="DownloadResourceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistrationResourceTests.cs" />
+    <Compile Include="ReportAbuseTests.cs" />
     <Compile Include="ResolverMetadataClientTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UIMetadataResourceTests.cs" />

--- a/test/Client.V3Test/ReportAbuseTests.cs
+++ b/test/Client.V3Test/ReportAbuseTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Client;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Client.V3Test
+{
+    public class ReportAbuseTests
+    {
+        [Fact]
+        public void ConstructorThrowsArgumentNullExceptionForNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new V3ReportAbuseResource(null));
+        }
+
+        [Fact]
+        public void ConstructorThrowsArgumentNullExceptionForEmpty()
+        {
+            Assert.Throws<ArgumentNullException>(() => new V3ReportAbuseResource(Enumerable.Empty<Uri>()));
+        }
+
+        [Fact]
+        public void GetFirstUncheckedUriAppliesTemplate()
+        {
+            // Arrange
+            var templates = new[] {
+                new Uri("http://report.abuse/{id}/{version}/{id-lower}/{version-lower}", UriKind.Absolute),
+                new Uri("http://report.abuse/will-not-be-evaluated", UriKind.Absolute)
+            };
+
+            var resource = new V3ReportAbuseResource(templates);
+
+            // Act
+            Uri actual = resource.GetReportAbuseUrl("PackageID", new NuGetVersion("1.2.3-RC"));
+
+            // Assert
+            Assert.Equal(new Uri("http://report.abuse/PackageID/1.2.3-RC/packageid/1.2.3-rc", UriKind.Absolute), actual);
+        }
+
+        [Fact]
+        public async void UnavailableUrlsAreNotReturned()
+        {
+            // Arrange
+            var templates = new[] {
+                new Uri("http://doesnotexist.nuget.org/{id-lower}/{version-lower}", UriKind.Absolute),
+                new Uri("http://doesnotexist.nuget.org/{id}/{version}", UriKind.Absolute)
+            };
+
+            var resource = new V3ReportAbuseResource(templates);
+
+            // Act
+            Uri actual = await resource.GetReportAbuseUrl("PackageID", new NuGetVersion("1.2.3-RC"), new System.Threading.CancellationToken());
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public async void FirstAvailableUrlIsReturned()
+        {
+            // Arrange
+            var templates = new[] {
+                new Uri("http://doesnotexist.nuget.org/{id-lower}/{version-lower}", UriKind.Absolute),
+                new Uri("http://api.nuget.org/v3/index.json", UriKind.Absolute) // All we need is a document that we know exists
+            };
+
+            var resource = new V3ReportAbuseResource(templates);
+
+            // Act
+            Uri actual = await resource.GetReportAbuseUrl("PackageID", new NuGetVersion("1.2.3-RC"), new System.Threading.CancellationToken());
+
+            // Assert
+            Assert.Equal(templates[1], actual);
+        }
+    }
+}

--- a/test/DataClientTest/DataTest.csproj
+++ b/test/DataClientTest/DataTest.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>DataTest</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>00ae921c</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +39,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Versioning, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.3.0.0-beta\lib\portable-net40+win\NuGet.Versioning.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -58,6 +63,7 @@
     <Compile Include="DataClientTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestJson.cs" />
+    <Compile Include="UriTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DataClient\Data.csproj">

--- a/test/DataClientTest/DataTest.csproj
+++ b/test/DataClientTest/DataTest.csproj
@@ -39,7 +39,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Versioning">
       <HintPath>..\..\packages\NuGet.Versioning.3.0.0-beta\lib\portable-net40+win\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/test/DataClientTest/UriTests.cs
+++ b/test/DataClientTest/UriTests.cs
@@ -1,0 +1,75 @@
+﻿using NuGet.Data;
+using NuGet.Versioning;
+using System;
+using Xunit;
+using Xunit.Extensions;
+
+namespace DataTest
+{
+    public class UriTests
+    {
+        /// <summary>
+        /// Test out our package uri template processing with all of the tokens we support.
+        /// </summary>
+        /// <remarks>
+        /// Be sure to check for case preservation along with the lower-case version of id/version.
+        /// </remarks>
+        [Theory]
+        [InlineData("http://foo.com/", "packageId", "1.0.0-Beta", "http://foo.com/")]
+        [InlineData("http://foo.com/{id}", "packageId", "1.0.0-Beta", "http://foo.com/packageId")]
+        [InlineData("http://foo.com/{id-lower}", "packageId", "1.0.0-Beta", "http://foo.com/packageid")]
+        [InlineData("http://foo.com/{version}", "packageId", "1.0.0-Beta", "http://foo.com/1.0.0-Beta")]
+        [InlineData("http://foo.com/{version-lower}", "packageId", "1.0.0-Beta", "http://foo.com/1.0.0-beta")]
+        [InlineData("http://foo.com/{id}/{version}", "packageId", "1.0.0-Beta", "http://foo.com/packageId/1.0.0-Beta")]
+        [InlineData("http://foo.com/{id-lower}/{version-lower}", "packageId", "1.0.0-Beta", "http://foo.com/packageid/1.0.0-beta")]
+        [InlineData("http://foo.com/query?id={id}&version={version}", "packageId", "1.0.0-Beta", "http://foo.com/query?id=packageId&version=1.0.0-Beta")]
+        public void ApplyPackageIdVersionToUriTemplate(string template, string id, string version, string expected)
+        {
+            var nugetVersion = new NuGetVersion(version);
+            var actual = Utility.ApplyPackageIdVersionToUriTemplate(new Uri(template), id, nugetVersion);
+            Assert.Equal(expected, actual.ToString());
+        }
+
+        /// <summary>
+        /// Test out our package uri template processing with all of the tokens we support.
+        /// </summary>
+        /// <remarks>
+        /// Be sure to check for case preservation along with the lower-case version of id/version.
+        /// </remarks>
+        [Theory]
+        [InlineData("http://foo.com/", "packageId", "http://foo.com/")]
+        [InlineData("http://foo.com/{id}", "packageId", "http://foo.com/packageId")]
+        [InlineData("http://foo.com/{id-lower}", "packageId", "http://foo.com/packageid")]
+        [InlineData("http://foo.com/query?id={id}", "packageId", "http://foo.com/query?id=packageId")]
+        public void ApplyPackageIdToUriTemplate(string template, string id, string expected)
+        {
+            var actual = Utility.ApplyPackageIdToUriTemplate(new Uri(template), id);
+            Assert.Equal(expected, actual.ToString());
+        }
+
+        [Fact]
+        public void ApplyPackageIdToUriTemplates()
+        {
+            var templates = new Uri[] { new Uri("http://foo.com/{id}", UriKind.Absolute), new Uri("http://bar.com/{id-lower}", UriKind.Absolute) };
+            var packageId = "packageId";
+
+            var expected = new Uri[] { new Uri("http://foo.com/packageId", UriKind.Absolute), new Uri("http://bar.com/packageid", UriKind.Absolute) };
+            var actual = Utility.ApplyPackageIdToUriTemplate(templates, packageId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ApplyPackageIdVersionToUriTemplates()
+        {
+            var templates = new Uri[] { new Uri("http://foo.com/{id}/{version}", UriKind.Absolute), new Uri("http://bar.com/{id-lower}/{version-lower}", UriKind.Absolute) };
+            var packageId = "packageId";
+            var packageVersion = new NuGetVersion("1.0.0-Beta");
+
+            var expected = new Uri[] { new Uri("http://foo.com/packageId/1.0.0-Beta", UriKind.Absolute), new Uri("http://bar.com/packageid/1.0.0-beta", UriKind.Absolute) };
+            var actual = Utility.ApplyPackageIdVersionToUriTemplate(templates, packageId, packageVersion);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/DataClientTest/packages.config
+++ b/test/DataClientTest/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="json-ld.net" version="1.0.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="json-ld.net" version="1.0.4" targetFramework="net45" userInstalled="true" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" userInstalled="true" />
+  <package id="NuGet.Versioning" version="3.0.0-beta" targetFramework="net45" userInstalled="true" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Note that we'll need to change the index.json type for Report Abuse to be ReportAbuseUriTemplate/3.0.0-beta.